### PR TITLE
fat: Fix implicit declaration of of sdmmc_sd_startup()

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,16 +18,11 @@ jobs:
     name: Build with Docker using devkitARM
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Make application
         run: |
           make
-      - name: Prepare for build publishing
-        run: |
-          mkdir -p ~/artifacts
-          cp -f FastVideoDS.nds ~/artifacts/
       - name: Publish build to GH Actions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          path: ~/artifacts/*
-          name: build
+          path: FastVideoDS.nds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,15 @@ jobs:
     name: Build with Docker using devkitARM
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Make application
         run: |
           make
-      - name: Prepare for build publishing
-        run: |
-          mkdir -p ~/artifacts
-          cp -f FastVideoDS.nds ~/artifacts/
       - name: Publish build to GH Actions
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          path: ~/artifacts/*
-          name: build
+          path: FastVideoDS.nds
+
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')

--- a/arm7/source/fat/diskio.c
+++ b/arm7/source/fat/diskio.c
@@ -35,6 +35,8 @@ extern FN_MEDIUM_READSECTORS _DLDI_readSectors_ptr;
 /* Inidialize a Drive                                                    */
 /*-----------------------------------------------------------------------*/
 
+void sdmmc_sd_startup();
+
  DSTATUS disk_initialize (
 	BYTE pdrv				/* Physical drive nmuber to identify the drive */
 )


### PR DESCRIPTION
This symbol is not exported by libnds, so it needs to be defined in this file to fix Wimplicit-function-declaration, which is now an error in GCC 14.

Fix an issue with the workflow for updated actions scripts.