### PR TITLE
Add build flag for 32KB DLDI support, and allow DLDI to mount in DSi …

### DIFF
--- a/arm7/source/fvPlayer7.c
+++ b/arm7/source/fvPlayer7.c
@@ -8,6 +8,12 @@
 #include "../../common/twlwram.h"
 #include "fvPlayer7.h"
 
+#ifdef LARGE_DLDI
+#define dldiLen 0x80 // Header only (DLDI is run from main memory)
+#else
+#define dldiLen 16 * 1024
+#endif
+
 #define FV_AUDIO_START_OFFSET 12
 
 #define FV_AUDIO_CH_LEFT  1
@@ -315,11 +321,8 @@ static void handleFifo(u32 value)
 
         case IPC_CMD_SETUP_DLDI:
         {
-            if (!isDSiMode())
-            {
-                memcpy((void*)0x037F8000, (void*)(value & IPC_CMD_ARG_MASK), 16 * 1024);
-                fat_mountDldi();
-            }
+            memcpy((void*)0x037F8000, (void*)(value & IPC_CMD_ARG_MASK), dldiLen);
+            fat_mountDldi();
             fifoSendValue32(FIFO_USER_01, IPC_CMD_PACK(IPC_CMD_SETUP_DLDI, 0));
             break;
         }

--- a/arm9/source/dldi_stub.s
+++ b/arm9/source/dldi_stub.s
@@ -30,7 +30,11 @@
 	.global gDldiStub
 @---------------------------------------------------------------------------------
 
+#ifdef LARGE_DLDI
+.equ DLDI_ALLOCATED_SPACE,		32768
+#else
 .equ DLDI_ALLOCATED_SPACE,		16384
+#endif
 
 gDldiStub:
 
@@ -41,9 +45,15 @@ dldi_start:
 	.word	0xBF8DA5ED		@ Magic number to identify this region
 	.asciz	" Chishm"		@ Identifying Magic string (8 bytes with null terminator)
 	.byte	0x01			@ Version number
+#ifdef LARGE_DLDI
+	.byte	DLDI_SIZE_32KB	@32KiB	@ Log [base-2] of the size of this driver in bytes.
+	.byte	0x00			@ Sections to fix
+	.byte 	DLDI_SIZE_32KB	@32KiB	@ Log [base-2] of the allocated space in bytes.
+#else
 	.byte	DLDI_SIZE_16KB	@16KiB	@ Log [base-2] of the size of this driver in bytes.
 	.byte	0x00			@ Sections to fix
 	.byte 	DLDI_SIZE_16KB	@16KiB	@ Log [base-2] of the allocated space in bytes.
+#endif
 	
 @---------------------------------------------------------------------------------
 @ Text identifier - can be anything up to 47 chars + terminating null -- 16 bytes
@@ -53,8 +63,13 @@ dldi_start:
 @---------------------------------------------------------------------------------
 @ Offsets to important sections within the data	-- 32 bytes
 	.align	6
-	.word   0x037F8000 //dldi_start		@ data start
-	.word   0x037FC000 //dldi_end		@ data end
+#ifdef LARGE_DLDI
+	.word   dldi_start		@ data start
+	.word   dldi_end		@ data end
+#else
+	.word   0x037F8000		@ data start
+	.word   0x037FC000		@ data end
+#endif
 	.word	0x00000000		@ Interworking glue start	-- Needs address fixing
 	.word	0x00000000		@ Interworking glue end
 	.word   0x00000000		@ GOT start					-- Needs address fixing

--- a/arm9/source/main.cpp
+++ b/arm9/source/main.cpp
@@ -8,6 +8,12 @@
 #include "gui/PlayerController.h"
 #include "../../common/twlwram.h"
 
+#ifdef LARGE_DLDI
+#define dldiLen 32 * 1024
+#else
+#define dldiLen 16 * 1024
+#endif
+
 static DTCM_BSS fv_player_t sPlayer;
 
 static PlayerController* sPlayerController;
@@ -40,10 +46,10 @@ int main(int argc, char** argv)
     if (canUseWram && (handShake & IPC_CMD_ARG_MASK) == 0)
         canUseWram = false;
 
-    if (!isDSiMode())
+    if (!isDSiMode() || (argc >= 2 && strncmp(argv[1], "fat:", 4) == 0))
     {
-        // setup dldi on arm7 if not on dsi
-        DC_FlushRange(gDldiStub, 16 * 1024);
+        // setup dldi on arm7
+        DC_FlushRange(gDldiStub, dldiLen);
         fifoSendValue32(FIFO_USER_01, IPC_CMD_PACK(IPC_CMD_SETUP_DLDI, (u32)gDldiStub));
         fifoWaitValue32(FIFO_USER_01);
         fifoGetValue32(FIFO_USER_01);


### PR DESCRIPTION
…mode

Due to arm7 (W)RAM limitations, 32KB DLDI is run from main memory, which can result in slightly slow video playback.